### PR TITLE
修复:1,代码块只滚动到一个匹配文本; 2,分屏时多个搜索框

### DIFF
--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -26,10 +26,6 @@
 - 文本框在 0.4 秒内无编辑则自动搜索
 - 只搜索在文档区域内的文本，不包含界面和文档标题
 
-问题：
-
-- 代码块内无语法高亮的文本在搜索时无法移动到界面中央，所以不适合用于搜索代码块内的文本
-
 #### 更新
 
 ##### 2024-03-27
@@ -56,5 +52,9 @@
 
 - 改进暗黑模式下的颜色
 - 支持带文本样式和超链接的搜索 [#11](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork/pull/11) ，但引入了新问题：分屏时只能搜索到左上角页签中的内容
-- 如果搜索框已弹出，再次点击顶栏按钮或快捷键时，会重新将焦点移动到搜索框并全选内容 [#9](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork/issues/9)
-- 分屏时只打开一个输入框 [#12](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork/issues/12)
+- 如果搜索框已弹出，再次点击顶栏按钮或快捷键时，会重新将焦点移动到当前聚焦的页签中的搜索框并全选内容 [#9](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork/issues/9)
+
+##### 2024-04-18
+
+- 分屏时在当前聚焦页签打开搜索框，支持在不同的页签中单独搜索 [#14](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork/pull/14)
+- 代码块内无语法高亮的文本在搜索时可以移动到界面中央了 [#14](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork/pull/14)

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-plugin-hsr-mdzz2048-fork",
   "author": "TCOTC",
   "url": "https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "minAppVersion": "2.9.8",
   "backends": ["windows", "linux", "darwin"],
   "frontends": ["desktop", "browser-desktop"],

--- a/src/Search.vue
+++ b/src/Search.vue
@@ -165,7 +165,9 @@ function highlightHitResult(value: string, change: boolean) { // 搜索并高亮
     // 首先，选取所有符合条件的元素
     // const elements = document.querySelectorAll('.layout-tab-container > div:not(.fn__none) .protyle-wysiwyg [data-node-id]');
     // 获取文档根,后续直接对全文档文本进行搜索,
-    const docRoot = document.querySelector('.layout-tab-container > div:not(.fn__none) .protyle-wysiwyg') as HTMLElement;
+    const docRoot = props.document.querySelector('.layout-tab-container > div:not(.fn__none) .protyle-wysiwyg') as HTMLElement;
+    //console.log("docRoot:")
+    //console.log(docRoot)
     const docText=docRoot.textContent.toLowerCase();
     const docLen=docText.length;
 
@@ -236,9 +238,15 @@ function highlightHitResult(value: string, change: boolean) { // 搜索并高亮
 function scroollIntoRanges(index: number) {
     const ranges = resultRange.value as Range[]
     const range = ranges[index]
-    const parent = range.commonAncestorContainer.parentElement
-    parent.scrollIntoView({ behavior: 'smooth', block: "center" })
+    // const parent = range.commonAncestorContainer.parentElement
+    // parent.scrollIntoView({ behavior: 'smooth', block: "center" })
 
+    const docContentElement  = props.document.querySelector('.layout-tab-container > div:not(.fn__none) >.protyle-content') as HTMLElement;
+    let doc_rect=docContentElement.getBoundingClientRect()
+    let mid_y=doc_rect.top+doc_rect.height/2
+    let range_rect = range.getBoundingClientRect();
+    docContentElement.scrollBy(0,range_rect.y-mid_y)
+  
     CSS.highlights.set("search-focus", new Highlight(range))
 }
 function clickLast() { // 上一个

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export default class PluginHighlight extends Plugin {
     }
 
     addSearchElement() {
-        const edits = document.querySelectorAll(".layout__center");
+        const edits = document.querySelectorAll(".layout__center [data-type='wnd'].layout__wnd--active > .layout-tab-container");
         console.log(edits);
         edits.forEach(edit => {
             const existingElement = edit.querySelector(`.${CLASS_NAME}`);


### PR DESCRIPTION
- 修复：[代码块内无语法高亮的文本在搜索时无法移动到界面中央 · Issue #8 · TCOTC/siyuan-plugin-hsr-mdzz2048-fork](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork/issues/8)
- 分屏时多个搜索框，实现每个页签单独搜索 #13