### PR TITLE
Fix crash when running on a browser

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
     // 在这里自定义变量
     define: {
         "process.env.DEV_MODE": `"${isWatch}"`,
+        "process.env": {},
     },
 
     build: {


### PR DESCRIPTION
 * The crash was due to `process` being undefined, since it's only available in NodeJS.